### PR TITLE
Update columns of ballot manifest view

### DIFF
--- a/openrla-assistant/frontend/src/component/election/BallotManifestCard/BallotManifest.jsx
+++ b/openrla-assistant/frontend/src/component/election/BallotManifestCard/BallotManifest.jsx
@@ -19,7 +19,6 @@ const BallotManifest = ({ ballots }) => {
   const makeRow = ({ id, filePath, srcPath }) => (
     <TableRow>
       <TableRowColumn>{id}</TableRowColumn>
-      <TableRowColumn>{filePath}</TableRowColumn>
       <TableRowColumn>{srcPath}</TableRowColumn>
     </TableRow>
   );
@@ -33,7 +32,6 @@ const BallotManifest = ({ ballots }) => {
           <TableRow>
             <TableHeaderColumn>ID</TableHeaderColumn>
             <TableHeaderColumn>Path</TableHeaderColumn>
-            <TableHeaderColumn>Original Path</TableHeaderColumn>
           </TableRow>
         </TableHeader>
         <TableBody displayRowCheckbox={false} children={rows} />


### PR DESCRIPTION
For #66.

Right now we are only using the "source" path in the backend. Furthermore, we'll eventually either remove the "source"/"current" file path distinction, or use it differently. Either way, the only path we should show in this view is the path described by the ballot manifest.